### PR TITLE
53 front task modify page path in mypage

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -10,6 +10,7 @@ import ThickDivider from "@/components/MyPage/dividers/ThickDivider/ThickDivider
 import InformationCard from "@/components/MyPage/InformationCard/InformationCard";
 import MenuListItem from "@/components/MyPage/MenuListItem/MenuListItem";
 
+import { INFORMATIONS_DATA, MENU_ITEMS_DATA } from "@/constants/mypage";
 import { PATH } from "@/constants/path";
 
 export default function MyPage() {
@@ -63,20 +64,17 @@ export default function MyPage() {
           <InformationCard
             navigateTo={PATH.STUDY_JOINING_LIST}
             count={2}
-            iconUrl="/svg/ic-mypage-bookmark.svg"
-            title="스터디"
+            informationData={INFORMATIONS_DATA.STUDY}
           />
           <InformationCard
             navigateTo={PATH.STUDY_INTEREST_LIST}
             count={9}
-            iconUrl="/svg/ic-mypage-scrap.svg"
-            title="스크랩"
+            informationData={INFORMATIONS_DATA.SCRAP}
           />
           <InformationCard
             navigateTo={PATH.USER_FOLLOW_LIST(1)}
             count={13}
-            iconUrl="/svg/ic-mypage-study-friends.svg"
-            title="스터디 친구"
+            informationData={INFORMATIONS_DATA.FOLLOW}
           />
         </section>
       </div>
@@ -104,20 +102,9 @@ export default function MyPage() {
         <div className="flex flex-col gap-6">
           <header className="text-bold-18">내 스터디</header>
           <ul className="flex flex-col gap-4">
-            <MenuListItem
-              navigateTo={PATH.STUDY_JOINING_LIST}
-              title="참여 중인 스터디"
-              icon={<Image src="/svg/ic-joining-study.svg" alt="joning" width={11} height={14} />}
-              isPrimary
-              studyCount={2}
-            />
+            <MenuListItem menuItemData={MENU_ITEMS_DATA.JOINING} isPrimary studyCount={2} />
 
-            <MenuListItem
-              navigateTo={PATH.STUDY_LAST_LIST}
-              title="지난 스터디"
-              icon={<Image src="/svg/ic-last-study.svg" alt="last" width={11} height={10} />}
-              studyCount={8}
-            />
+            <MenuListItem menuItemData={MENU_ITEMS_DATA.PAST} studyCount={8} />
           </ul>
         </div>
 
@@ -130,25 +117,10 @@ export default function MyPage() {
             <MenuListItem
               // TODO: 최근 방문한 관심 스터디 ID로 수정
               navigateTo={PATH.STUDY(1)}
-              title="최근 방문"
-              icon={
-                <Image
-                  src="/svg/ic-study-recent-visit.svg"
-                  alt="recent visit"
-                  width={15}
-                  height={15}
-                />
-              }
+              menuItemData={MENU_ITEMS_DATA.RECENT_VISIT}
             />
 
-            <MenuListItem
-              navigateTo={PATH.STUDY_INTEREST_LIST}
-              title="관심 스터디"
-              icon={
-                <Image src="/svg/ic-study-interested.svg" alt="intersted" width={15} height={15} />
-              }
-              studyCount={8}
-            />
+            <MenuListItem menuItemData={MENU_ITEMS_DATA.INTEREST} studyCount={8} />
           </ul>
         </div>
       </div>
@@ -160,9 +132,9 @@ export default function MyPage() {
         <div className="flex flex-col gap-6">
           <header className="text-bold-18">고객 센터</header>
           <ul className="flex flex-col gap-4">
-            <MenuListItem navigateTo={PATH.FAQ} title="FAQ" />
-            <MenuListItem navigateTo={PATH.INQUIRY} title="문의하기" />
-            <MenuListItem navigateTo={PATH.NOTI} title="공지사항" isUpdated />
+            <MenuListItem menuItemData={MENU_ITEMS_DATA.FAQ} />
+            <MenuListItem menuItemData={MENU_ITEMS_DATA.INQUIRY} />
+            <MenuListItem menuItemData={MENU_ITEMS_DATA.NOTIFICATION} isUpdated />
           </ul>
         </div>
 
@@ -172,10 +144,13 @@ export default function MyPage() {
         <div className="flex flex-col gap-6">
           <header className="text-bold-18">계정 정보</header>
           <ul className="flex flex-col gap-4">
-            <MenuListItem navigateTo={PATH.USER_PROFILE_EDIT(1)} title="회원 정보 수정" />
-            <MenuListItem navigateTo={PATH.PASSWORD} title="비밀번호 설정" />
-            <MenuListItem title="마케팅 개인정보 제 3자 제공동의" isToggle={true} />
-            <MenuListItem navigateTo={PATH.WITHDRAW} title="회원 탈퇴" />
+            <MenuListItem
+              navigateTo={PATH.USER_PROFILE_EDIT(1)}
+              menuItemData={MENU_ITEMS_DATA.PROFIL_EDIT}
+            />
+            <MenuListItem menuItemData={MENU_ITEMS_DATA.PASSWORD_EDIT} />
+            <MenuListItem menuItemData={MENU_ITEMS_DATA.INFORMATION_AGREEMENT} isToggle={true} />
+            <MenuListItem menuItemData={MENU_ITEMS_DATA.WITHDRAW} />
           </ul>
         </div>
       </div>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -172,7 +172,7 @@ export default function MyPage() {
         <div className="flex flex-col gap-6">
           <header className="text-bold-18">계정 정보</header>
           <ul className="flex flex-col gap-4">
-            <MenuListItem navigateTo={PATH.USER_PROFILE(1)} title="회원 정보 수정" />
+            <MenuListItem navigateTo={PATH.USER_PROFILE_EDIT(1)} title="회원 정보 수정" />
             <MenuListItem navigateTo={PATH.PASSWORD} title="비밀번호 설정" />
             <MenuListItem title="마케팅 개인정보 제 3자 제공동의" isToggle={true} />
             <MenuListItem navigateTo={PATH.WITHDRAW} title="회원 탈퇴" />

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -62,19 +62,19 @@ export default function MyPage() {
         <header className="text-bold-18">내 정보</header>
         <section className="grid grid-cols-3 border border-primary-200 rounded-lg py-9 bg-primary-50">
           <InformationCard
-            navigateTo={PATH.STUDY_JOINING_LIST}
             count={2}
             informationData={INFORMATIONS_DATA.STUDY}
+            navigateTo={PATH.STUDY_JOINING_LIST}
           />
           <InformationCard
-            navigateTo={PATH.STUDY_INTEREST_LIST}
             count={9}
             informationData={INFORMATIONS_DATA.SCRAP}
+            navigateTo={PATH.STUDY_INTEREST_LIST}
           />
           <InformationCard
-            navigateTo={PATH.USER_FOLLOW_LIST(1)}
             count={13}
             informationData={INFORMATIONS_DATA.FOLLOW}
+            navigateTo={PATH.USER_FOLLOW_LIST(1)}
           />
         </section>
       </div>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -60,9 +60,20 @@ export default function MyPage() {
       <div className="flex flex-col gap-3 px-4 mt-9">
         <header className="text-bold-18">내 정보</header>
         <section className="grid grid-cols-3 border border-primary-200 rounded-lg py-9 bg-primary-50">
-          <InformationCard count={2} iconUrl="/svg/ic-mypage-bookmark.svg" title="스터디" />
-          <InformationCard count={9} iconUrl="/svg/ic-mypage-scrap.svg" title="스크랩" />
           <InformationCard
+            navigateTo={PATH.STUDY_JOINING_LIST}
+            count={2}
+            iconUrl="/svg/ic-mypage-bookmark.svg"
+            title="스터디"
+          />
+          <InformationCard
+            navigateTo={PATH.STUDY_INTEREST_LIST}
+            count={9}
+            iconUrl="/svg/ic-mypage-scrap.svg"
+            title="스크랩"
+          />
+          <InformationCard
+            navigateTo={PATH.USER_FOLLOW_LIST(1)}
             count={13}
             iconUrl="/svg/ic-mypage-study-friends.svg"
             title="스터디 친구"
@@ -94,7 +105,7 @@ export default function MyPage() {
           <header className="text-bold-18">내 스터디</header>
           <ul className="flex flex-col gap-4">
             <MenuListItem
-              navigateTo={PATH.JOINING_STUDY}
+              navigateTo={PATH.STUDY_JOINING_LIST}
               title="참여 중인 스터디"
               icon={<Image src="/svg/ic-joining-study.svg" alt="joning" width={11} height={14} />}
               isPrimary
@@ -102,7 +113,7 @@ export default function MyPage() {
             />
 
             <MenuListItem
-              navigateTo={PATH.LAST_STUDY}
+              navigateTo={PATH.STUDY_LAST_LIST}
               title="지난 스터디"
               icon={<Image src="/svg/ic-last-study.svg" alt="last" width={11} height={10} />}
               studyCount={8}
@@ -117,7 +128,8 @@ export default function MyPage() {
           <header className="text-bold-18">관심 보인 스터디</header>
           <ul className="flex flex-col gap-4">
             <MenuListItem
-              navigateTo={PATH.INTEREST_RECENT_VISIT}
+              // TODO: 최근 방문한 관심 스터디 ID로 수정
+              navigateTo={PATH.STUDY(1)}
               title="최근 방문"
               icon={
                 <Image
@@ -130,7 +142,7 @@ export default function MyPage() {
             />
 
             <MenuListItem
-              navigateTo={PATH.INTEREST}
+              navigateTo={PATH.STUDY_INTEREST_LIST}
               title="관심 스터디"
               icon={
                 <Image src="/svg/ic-study-interested.svg" alt="intersted" width={15} height={15} />

--- a/src/components/MyPage/InformationCard/InformationCard.tsx
+++ b/src/components/MyPage/InformationCard/InformationCard.tsx
@@ -1,20 +1,24 @@
 import Image from "next/image";
 import Link from "next/link";
 
+interface InformationDataType {
+  title: string;
+  icon: string;
+}
+
 interface InformationCardProps {
   count: number;
-  iconUrl: string;
-  title: string;
+  informationData: InformationDataType;
   navigateTo: string;
 }
 
-const InformationCard = ({ count, iconUrl, title, navigateTo }: InformationCardProps) => {
+const InformationCard = ({ count, informationData, navigateTo }: InformationCardProps) => {
   return (
     <Link href={navigateTo}>
       <article className="flex flex-col gap-3 items-center relative after:h-2.5 after:absolute after:top-12 after:-right-0 after:border after:border-primary-200 last:after:hidden">
-        <Image src={iconUrl} alt={title} width={41} height={41} />
+        <Image src={informationData.icon} alt={informationData.title} width={41} height={41} />
         <div className="flex flex-col gap-2 items-center">
-          <p className="text-blue-300 text-regular-16">{title}</p>
+          <p className="text-blue-300 text-regular-16">{informationData.title}</p>
           <p className="text-bold-18">{count}</p>
         </div>
       </article>

--- a/src/components/MyPage/InformationCard/InformationCard.tsx
+++ b/src/components/MyPage/InformationCard/InformationCard.tsx
@@ -1,20 +1,24 @@
 import Image from "next/image";
+import Link from "next/link";
 
 interface InformationCardProps {
   count: number;
   iconUrl: string;
   title: string;
+  navigateTo: string;
 }
 
-const InformationCard = ({ count, iconUrl, title }: InformationCardProps) => {
+const InformationCard = ({ count, iconUrl, title, navigateTo }: InformationCardProps) => {
   return (
-    <article className="flex flex-col gap-3 items-center relative after:h-2.5 after:absolute after:top-12 after:-right-0 after:border after:border-primary-200 last:after:hidden">
-      <Image src={iconUrl} alt={title} width={41} height={41} />
-      <div className="flex flex-col gap-2 items-center">
-        <p className="text-blue-300 text-regular-16">{title}</p>
-        <p className="text-bold-18">{count}</p>
-      </div>
-    </article>
+    <Link href={navigateTo}>
+      <article className="flex flex-col gap-3 items-center relative after:h-2.5 after:absolute after:top-12 after:-right-0 after:border after:border-primary-200 last:after:hidden">
+        <Image src={iconUrl} alt={title} width={41} height={41} />
+        <div className="flex flex-col gap-2 items-center">
+          <p className="text-blue-300 text-regular-16">{title}</p>
+          <p className="text-bold-18">{count}</p>
+        </div>
+      </article>
+    </Link>
   );
 };
 

--- a/src/components/MyPage/MenuListItem/MenuListItem.tsx
+++ b/src/components/MyPage/MenuListItem/MenuListItem.tsx
@@ -7,9 +7,14 @@ import type { ReactNode } from "react";
 
 import Toggle from "../Toggle/Toggle";
 
-interface MenuListItemProps {
+interface MenuItemDataType {
   title: string;
   icon?: ReactNode;
+  navigateTo?: string;
+}
+
+interface MenuListItemProps {
+  menuItemData: MenuItemDataType;
   isToggle?: boolean;
   isUpdated?: boolean;
   isPrimary?: boolean;
@@ -18,8 +23,7 @@ interface MenuListItemProps {
 }
 
 const MenuListItem = ({
-  title,
-  icon,
+  menuItemData,
   isToggle,
   isUpdated,
   isPrimary,
@@ -29,7 +33,9 @@ const MenuListItem = ({
   const router = useRouter();
 
   const handleClick = () => {
-    if (navigateTo) {
+    if (menuItemData.navigateTo) {
+      router.push(menuItemData.navigateTo);
+    } else if (navigateTo) {
       router.push(navigateTo);
     }
     // TODO: 토글 on/off 구현
@@ -37,13 +43,13 @@ const MenuListItem = ({
 
   return (
     <li onClick={handleClick}>
-      <article className="flex justify-between items-center">
+      <article className="flex justify-between items-center cursor-pointer">
         <div className="flex gap-2 items-center">
-          {icon}
+          {menuItemData.icon}
           <p
             className={`text-medium-16 text-gray-600 ${isUpdated && "relative after:absolute after:h-2 after:w-2 after:rounded-full after:top-0 after:-right-2 after:bg-red-500"}`}
           >
-            {title}
+            {menuItemData.title}
           </p>
           {studyCount && (
             <div className={isPrimary ? "w-5 h-5 rounded-full bg-blue-100 text-primary-500" : ""}>

--- a/src/components/MyPage/MenuListItem/MenuListItem.tsx
+++ b/src/components/MyPage/MenuListItem/MenuListItem.tsx
@@ -3,13 +3,11 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 
-import type { ReactNode } from "react";
-
 import Toggle from "../Toggle/Toggle";
 
 interface MenuItemDataType {
   title: string;
-  icon?: ReactNode;
+  icon?: string;
   navigateTo?: string;
 }
 
@@ -45,7 +43,9 @@ const MenuListItem = ({
     <li onClick={handleClick}>
       <article className="flex justify-between items-center cursor-pointer">
         <div className="flex gap-2 items-center">
-          {menuItemData.icon}
+          {menuItemData.icon && (
+            <Image src={menuItemData.icon} alt="study menu" width={15} height={15} />
+          )}
           <p
             className={`text-medium-16 text-gray-600 ${isUpdated && "relative after:absolute after:h-2 after:w-2 after:rounded-full after:top-0 after:-right-2 after:bg-red-500"}`}
           >

--- a/src/components/MyPage/MenuListItem/MenuListItem.tsx
+++ b/src/components/MyPage/MenuListItem/MenuListItem.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 
-import Toggle from "../Toggle/Toggle";
+import Toggle from "@/components/MyPage/Toggle/Toggle";
 
 interface MenuItemDataType {
   title: string;

--- a/src/constants/mypage.ts
+++ b/src/constants/mypage.ts
@@ -1,5 +1,3 @@
-import Image from "next/image";
-
 import { PATH } from "./path";
 
 export const INFORMATIONS_DATA = {
@@ -20,21 +18,21 @@ export const INFORMATIONS_DATA = {
 export const MENU_ITEMS_DATA = {
   JOINING: {
     title: "참여 중인 스터디",
-    icon: <Image src="/svg/ic-joining-study.svg" alt="joning" width={11} height={14} />,
+    icon: "/svg/ic-joining-study.svg",
     navigateTo: PATH.STUDY_JOINING_LIST,
   },
   PAST: {
     title: "지난 스터디",
-    icon: <Image src="/svg/ic-last-study.svg" alt="joning" width={11} height={14} />,
+    icon: "/svg/ic-last-study.svg",
     navigateTo: PATH.STUDY_LAST_LIST,
   },
   RECENT_VISIT: {
     title: "최근 방문",
-    icon: <Image src="/svg/ic-study-recent-visit.svg" alt="recent visit" width={15} height={15} />,
+    icon: "/svg/ic-study-recent-visit.svg",
   },
   INTEREST: {
     title: "관심 스터디",
-    icon: <Image src="/svg/ic-study-interested.svg" alt="intersted" width={15} height={15} />,
+    icon: "/svg/ic-study-interested.svg",
     navigateTo: PATH.STUDY_INTEREST_LIST,
   },
 

--- a/src/constants/mypage.tsx
+++ b/src/constants/mypage.tsx
@@ -1,0 +1,66 @@
+import Image from "next/image";
+
+import { PATH } from "./path";
+
+export const INFORMATIONS_DATA = {
+  STUDY: {
+    title: "스터디",
+    icon: "/svg/ic-mypage-bookmark.svg",
+  },
+  SCRAP: {
+    title: "스크랩",
+    icon: "/svg/ic-mypage-scrap.svg",
+  },
+  FOLLOW: {
+    title: "스터디 친구",
+    icon: "/svg/ic-mypage-study-friends.svg",
+  },
+};
+
+export const MENU_ITEMS_DATA = {
+  JOINING: {
+    title: "참여 중인 스터디",
+    icon: <Image src="/svg/ic-joining-study.svg" alt="joning" width={11} height={14} />,
+    navigateTo: PATH.STUDY_JOINING_LIST,
+  },
+  PAST: {
+    title: "지난 스터디",
+    icon: <Image src="/svg/ic-last-study.svg" alt="joning" width={11} height={14} />,
+    navigateTo: PATH.STUDY_LAST_LIST,
+  },
+  RECENT_VISIT: {
+    title: "최근 방문",
+    icon: <Image src="/svg/ic-study-recent-visit.svg" alt="recent visit" width={15} height={15} />,
+  },
+  INTEREST: {
+    title: "관심 스터디",
+    icon: <Image src="/svg/ic-study-interested.svg" alt="intersted" width={15} height={15} />,
+    navigateTo: PATH.STUDY_INTEREST_LIST,
+  },
+  FAQ: {
+    title: "FAQ",
+    navigateTo: PATH.FAQ,
+  },
+  INQUIRY: {
+    title: "문의하기",
+    navigateTo: PATH.INQUIRY,
+  },
+  NOTIFICATION: {
+    title: "공지사항",
+    navigateTo: PATH.NOTI,
+  },
+  PROFIL_EDIT: {
+    title: "회원 정보 수정",
+  },
+  PASSWORD_EDIT: {
+    title: "비밀번호 설정",
+    navigateTo: PATH.PASSWORD,
+  },
+  INFORMATION_AGREEMENT: {
+    title: "마케팅 개인정보 제 3자 제공동의",
+  },
+  WITHDRAW: {
+    title: "회원 탈퇴",
+    navigateTo: PATH.WITHDRAW,
+  },
+};

--- a/src/constants/mypage.tsx
+++ b/src/constants/mypage.tsx
@@ -37,6 +37,7 @@ export const MENU_ITEMS_DATA = {
     icon: <Image src="/svg/ic-study-interested.svg" alt="intersted" width={15} height={15} />,
     navigateTo: PATH.STUDY_INTEREST_LIST,
   },
+
   FAQ: {
     title: "FAQ",
     navigateTo: PATH.FAQ,
@@ -49,6 +50,7 @@ export const MENU_ITEMS_DATA = {
     title: "공지사항",
     navigateTo: PATH.NOTI,
   },
+
   PROFIL_EDIT: {
     title: "회원 정보 수정",
   },

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -15,6 +15,8 @@ export const PATH = {
 
   USER_PROFILE: (userId: number) => `/user/${userId}`,
   USER_PROFILE_EDIT: (userId: number) => `/user/${userId}/edit`,
+  // TODO: 페이지 생성 후 PATH 수정
+  USER_FOLLOW_LIST: (userId: number) => `/user/${userId}/follow-list`,
 
   STUDY_ROOM_LIST: "/study-room/list",
   STUDY_EXPLORER: "/study-explorer",
@@ -26,10 +28,10 @@ export const PATH = {
   TASK_CONFIRM_SUCCESS: "/task-confirm/success",
   TASK_CONFIRM_ID: (taskId: number) => `/task-confirm/${taskId}`,
 
-  JOINING_STUDY: "/study/joining",
-  LAST_STUDY: "/study/last",
-  INTEREST: "/study/interested",
-  INTEREST_RECENT_VISIT: "/study/interested/recent",
+  // TODO: 페이지 생성 후 PATH 수정
+  STUDY_JOINING_LIST: "/study/joining", // 참여중인 스터디 리스트
+  STUDY_LAST_LIST: "/study/last", // 종료된 스터디 리스트
+  STUDY_INTEREST_LIST: "/study/interested", // 북마크한 관심 스터디 리스트
 
   FAQ: "/faq",
   INQUIRY: "/inquiry",


### PR DESCRIPTION
- https://github.com/Meetie-One/Meetie-front/issues/53

## 💡 변경사항 & 이슈
마이 페이지 메뉴 아이템 라우팅 경로 수정
내 정보 카드 페이지 라우팅 적용
메뉴 아이템 데이터 상수로 관리
<br>

## ✍️ 관련 설명
마이 페이지에서 메뉴 아이템의 라우팅 경로를 수정했습니다. 
- USER_FOLLOW_LIST 추가
  - 내정보/친구 클릭 시 이동
- INTEREST_RECENT_VISIT 제거
  - 최근 방문이어서 PATH.STUDY 사용
- 키 변경
  - JOINING_STUDY -> STUDY_JOINING_LIST
  - LAST_STUDY -> STUDY_LAST_LIST
  - INTEREST -> STUDY_INTEREST_LIST

메뉴 아이템 데이터를 상수로 관리할 수 있도록 분리했습니다.

계정 정보 - 회원 정보 수정의 라우팅 경로를 user/[id]에서 user/[id]/edit으로 변경햇습니다.

내 정보에서 각각의 카드를 선택 시 해당 페이지로 이동할 수 있도록 코드를 추가했습니다.
<br>

## ⭐️ Review point
코드 라인수를 줄이고 싶어서 메뉴 아이템 데이터를 상수로 분리했는데, 가독성이 괜찮은지 모르겠네요. 코드 수정할 부분이 있다면 말씀해주시길 바랍니다.
<br>

## 📷 Demo

<br>
