### PR TITLE
63 front task refactor onboarding data api handler

### DIFF
--- a/src/apis/onboarding/getOnboarding.ts
+++ b/src/apis/onboarding/getOnboarding.ts
@@ -1,0 +1,9 @@
+import { axiosInstance } from "@/apis/axiosInstance";
+
+import { END_POINTS } from "@/constants/api";
+
+export const getOnboarding = async () => {
+  const { data } = await axiosInstance.get(END_POINTS.ONBOARDING);
+
+  return data;
+};

--- a/src/apis/onboarding/postOnboarding.ts
+++ b/src/apis/onboarding/postOnboarding.ts
@@ -1,0 +1,13 @@
+import { axiosInstance } from "@/apis/axiosInstance";
+
+import { END_POINTS } from "@/constants/api";
+
+import type { OnboardingFormType } from "@/types/onboarding";
+
+export const postOnboarding = async (onboardingForm: OnboardingFormType) => {
+  const config = {
+    headers: { "Content-Type": "application/json" },
+  };
+
+  return axiosInstance.post(END_POINTS.ONBOARDING, onboardingForm, config);
+};

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -28,7 +28,7 @@ export async function GET() {
     const { data, error } = await supabase.from("onboarding").select("position, styles").single();
 
     if (data && !error) {
-      return NextResponse.json({ message: "ok", status: 200, data: data });
+      return NextResponse.json({ message: "ok", status: 200, data });
     }
 
     return NextResponse.json({ message: "ok", status: 200, data: null });

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -2,17 +2,12 @@ import { NextResponse } from "next/server";
 
 import { createClient } from "@/utils/supabase/server";
 
-interface PostDataTypes {
-  position: string;
-  purposes: string[];
-  styles: string[];
-  period: string;
-}
+import type { OnboardingFormType } from "@/types/onboarding";
 
 export async function POST(request: Request) {
   try {
     const supabase = createClient();
-    const postData: PostDataTypes = await request.json();
+    const postData: OnboardingFormType = await request.json();
 
     // TODO: 이미 저장된 정보 있는 지 확인
     const { error } = await supabase.from("onboarding").insert(postData);
@@ -30,10 +25,10 @@ export async function POST(request: Request) {
 export async function GET() {
   try {
     const supabase = createClient();
-    const { data, error } = await supabase.from("onboarding").select("position, styles");
+    const { data, error } = await supabase.from("onboarding").select("position, styles").single();
 
-    if (data && data.length !== 0 && !error) {
-      return NextResponse.json({ message: "ok", status: 200, data: data[0] });
+    if (data && !error) {
+      return NextResponse.json({ message: "ok", status: 200, data: data });
     }
 
     return NextResponse.json({ message: "ok", status: 200, data: null });

--- a/src/app/api/user-info/[id]/route.ts
+++ b/src/app/api/user-info/[id]/route.ts
@@ -19,7 +19,6 @@ export async function PATCH(request: Request, { params }: { params: { id: number
     const supabase = createClient();
 
     const data = await request.json();
-    console.log(data);
 
     const { error } = await supabase.from("userinfo").update(data).eq("id", params.id);
 

--- a/src/app/api/user-info/[id]/route.ts
+++ b/src/app/api/user-info/[id]/route.ts
@@ -19,6 +19,7 @@ export async function PATCH(request: Request, { params }: { params: { id: number
     const supabase = createClient();
 
     const data = await request.json();
+    console.log(data);
 
     const { error } = await supabase.from("userinfo").update(data).eq("id", params.id);
 

--- a/src/app/auth/redirect/page.tsx
+++ b/src/app/auth/redirect/page.tsx
@@ -4,7 +4,9 @@ import { useRouter } from "next/navigation";
 
 import { useEffect } from "react";
 
-import { createClient } from "@/utils/supabase/client";
+import { PATH } from "@/constants/path";
+
+import { useOnboardingCompleteQuery } from "@/hooks/api/onboarding/useOnboardingCompleteQuery";
 
 // 이후 온보딩 여부를 DB에서 가져와 체크후
 // 온보딩된 유저면 /study-room/list로 (로그인 상황)
@@ -13,18 +15,16 @@ import { createClient } from "@/utils/supabase/client";
 // 현재는 그냥 /walk-through로 이동
 
 export default function RedirectPage() {
-  const supabase = createClient();
-
   const router = useRouter();
-
-  (async () => {
-    const user = await supabase.auth.getUser();
-    console.log(user.data);
-  })();
+  const { isExist } = useOnboardingCompleteQuery();
 
   useEffect(() => {
-    router.push("/walk-through");
-  }, []);
+    if (isExist) {
+      router.push(PATH.STUDY_ROOM_LIST);
+    } else {
+      router.push(PATH.WALKTHROUGH);
+    }
+  }, [isExist]);
 
   return <div />;
 }

--- a/src/app/onboarding/complete/page.tsx
+++ b/src/app/onboarding/complete/page.tsx
@@ -1,128 +1,18 @@
-"use client";
+import { Suspense } from "react";
 
-import Image from "next/image";
-import Link from "next/link";
-
-import { useEffect, useState } from "react";
-
-import Button from "@/components/common/Button/Button";
-import OnBoardingTitle from "@/components/OnBoardingTitle/OnBoardingTitle";
-
-import { COMPLETE_DATA, JOBS_DATA, JOBS_KR_DATA } from "@/constants/onBoarding";
-import { PATH } from "@/constants/path";
-
-import { createClient } from "@/utils/supabase/client";
+import CompleteBox from "@/components/OnBoarding/CompleteBox/CompleteBox";
 
 export default function OnBoardingCompletePage() {
-  const [userName, setUserName] = useState("밋티");
-  const [profile, setProfile] = useState("");
-  const [job, setJob] = useState("");
-  const [styles, setStyles] = useState("");
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    // TODO: 추후에 리펙토링
-    (async () => {
-      const supabase = createClient();
-      const user = (await supabase.auth.getUser()).data.user;
-      if (!user) {
-        // TODO: 에러 추가
-        return;
-      }
-
-      const { avatar_url, name } = user.user_metadata;
-      setUserName(name);
-      setProfile(avatar_url);
-
-      const res = await fetch("http://localhost:3000/api/onboarding", {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      });
-      const result = await res.json();
-      const data: { position: string; styles: string[] } | null = result.data;
-
-      if (data) {
-        // TODO: job -> position 모두 변경 예정
-        const job: string = JOBS_KR_DATA[JOBS_DATA.indexOf(data.position)];
-        setJob(job);
-        // TODO: 글자 수 길어질 때 어떻게 할지 고민
-        const styles = data.styles.join("﹒");
-        setStyles(styles);
-      }
-
-      setIsLoading(false);
-    })();
-  }, []);
-
   return (
     <main className="flex flex-col h-screen">
-      <article className="flex flex-col items-center w-full h-full px-5">
-        <OnBoardingTitle
-          textData={COMPLETE_DATA(userName)}
-          index={0}
-          subTextColor="text-gray-200"
-        />
-
-        {isLoading ? (
-          // TODO: 로딩 컴포넌트로 교체 예정
-          "loading"
-        ) : (
-          <div className="relative w-[150px] mt-[77px]">
-            <Image
-              src="/svg/ic-onboarding-complete-back.svg"
-              width={146}
-              height={204}
-              alt="back"
-              priority
-              className="absolute top-0"
-            />
-
-            <div className="relative flex justify-center w-full transform animate-tilt backdrop-blur-[2px]">
-              <div className="w-[146px] h-[204px] border border-gray-100 rounded-lg bg-[#FAFAFF]/70" />
-              <div className="absolute top-0 flex flex-col items-center justify-center pt-6 whitespace-nowrap">
-                <div className="relative w-[80px] h-[80px] flex justify-center bg-gradient-to-tr from-[#FAFAFF]/60 to-[#FAFAFF]/45">
-                  <div className="absolute w-[80px] h-[80px] bg-[#0017E2] mix-blend-hue z-10" />
-                  <Image
-                    src="/svg/ic-badge-nanum-master.svg"
-                    width={76}
-                    height={75}
-                    alt="meetie master"
-                  />
-
-                  {profile && (
-                    <Image
-                      src={profile}
-                      width={48}
-                      height={48}
-                      alt="profile"
-                      priority
-                      className="absolute top-[25px] z-20 rounded-full"
-                    />
-                  )}
-                </div>
-                <p className="text-semibold-14 mt-[6.5px]">{userName}님</p>
-                <p className="text-semibold-10">{job}</p>
-                <p className="text-regular-12 mt-[19px]">{styles}</p>
-              </div>
-            </div>
-            <Image
-              src="/svg/ic-onboarding-profile-shadow.svg"
-              width={162}
-              height={15}
-              alt="profile shadow"
-              className="mt-[47px]"
-            />
-          </div>
-        )}
-
-        <Link href={PATH.STUDY_ROOM_LIST} className="mt-auto mb-[42px]">
-          <Button size="xl">
-            <span className="text-white text-semibold-16">스터디 찾으러 가기</span>
-          </Button>
-        </Link>
-      </article>
+      <Suspense
+        fallback={
+          // TODO: profile 로딩 컴포넌트로 변경 or 공통 로딩 컴포넌트로 변경
+          <div>loading...</div>
+        }
+      >
+        <CompleteBox />
+      </Suspense>
     </main>
   );
 }

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -2,110 +2,37 @@
 
 import { useRouter } from "next/navigation";
 
-import type { Dispatch, SetStateAction } from "react";
-import { useEffect, useState } from "react";
+import { Suspense } from "react";
 
 import Button from "@/components/common/Button/Button";
 import FirstStep from "@/components/OnBoarding/FirstStep/FirstStep";
 import FourthStep from "@/components/OnBoarding/FourthStep/FourthStep";
 import SecondStep from "@/components/OnBoarding/SecondStep/SecondStep";
 import ThirdStep from "@/components/OnBoarding/ThirdStep/ThirdStep";
-import OnBoardingTitle from "@/components/OnBoardingTitle/OnBoardingTitle";
+import TitleContainer from "@/components/OnBoarding/TitleContainer/TitleContainer";
 
-import { QUESTION_DATA, STEPS_DATA } from "@/constants/onBoarding";
 import { PATH } from "@/constants/path";
 
-import { createClient } from "@/utils/supabase/client";
+import { useOnboardingForm } from "@/hooks/onboarding/useOnboardingForm";
 
 export default function OnBoardingPage() {
   const router = useRouter();
-  const supabase = createClient();
 
-  const [step, setStep] = useState<"job" | "purpose" | "style" | "period">("job");
-
-  // TODO: 객체화 state 사용, hook으로 분리
-  const [job, setJob] = useState<string>("");
-  const [purpose, setPurpose] = useState<string[]>([]);
-  const [style, setStyle] = useState<string[]>([]);
-  const [period, setPeriod] = useState<string>("");
-
-  const [userName, setUserName] = useState("밋티");
-
-  // TODO: state 객체화 되면 수정
-  const isFilled =
-    (step === "job" && job.length !== 0) ||
-    (step === "purpose" && purpose.length !== 0) ||
-    (step === "style" && style.length !== 0) ||
-    (step === "period" && period.length !== 0);
-
-  // TODO: 로그인 기능 추가 후 해당 유저 정보로 수정
-  const currentStepIndex = STEPS_DATA.indexOf(step);
-
-  // TODO: state 객체화 되면 수정
-  const handleStringClick = (
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-    setValue: Dispatch<SetStateAction<string>>,
-  ) => {
-    setValue(e.currentTarget.value);
-  };
-
-  const handleArrayClick = (
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-    setValue: Dispatch<SetStateAction<string[]>>,
-  ) => {
-    const newValue = e.currentTarget.value;
-
-    setValue((prev) =>
-      prev.includes(newValue) ? prev.filter((item) => item !== newValue) : [...prev, newValue],
-    );
-  };
-
-  const handlePrevStep = () => {
-    step === "job" || setStep(STEPS_DATA[currentStepIndex - 1]);
-  };
-
-  const handleNextStep = () => {
-    step === "period" || setStep(STEPS_DATA[currentStepIndex + 1]);
-  };
-
-  const handlePostOnboardingData = async () => {
-    const data = { position: job, purposes: purpose, styles: style, period };
-
-    // TODO: 함수 모듈화
-    try {
-      const response = await fetch("http://localhost:3000/api/onboarding", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(data),
-      });
-
-      if (response.ok) {
-        router.push(PATH.ONBOARDING_COMPLETE);
-      }
-    } catch (error) {
-      console.error(error);
-    }
-  };
+  const {
+    step,
+    isFilled,
+    onBoardingForm,
+    currentStepIndex,
+    handleStringClick,
+    handleArrayClick,
+    handlePrevStep,
+    handleNextStep,
+    handleSubmit,
+  } = useOnboardingForm();
 
   const handleMoveComplete = () => {
     router.push(PATH.ONBOARDING_COMPLETE);
   };
-
-  useEffect(() => {
-    (async () => {
-      const user = (await supabase.auth.getUser()).data.user;
-
-      if (!user) {
-        // TODO: 에러 추가
-        return;
-      }
-
-      const { name } = user.user_metadata;
-      setUserName(name);
-    })();
-  }, []);
 
   return (
     <main className="flex flex-col h-full">
@@ -117,27 +44,39 @@ export default function OnBoardingPage() {
       </div>
 
       <article className="flex flex-col px-4 h-max">
-        <OnBoardingTitle
-          textData={QUESTION_DATA(userName)}
-          index={currentStepIndex}
-          subTextColor="text-gray-200"
-        />
+        <Suspense
+          fallback={
+            // TODO: 공통 로딩 컴포넌트로 교체
+            <div>로딩 컴포넌트</div>
+          }
+        >
+          <TitleContainer currentStepIndex={currentStepIndex} />
 
-        {step === "job" && (
-          <FirstStep clickedJob={job} handleClick={(e) => handleStringClick(e, setJob)} />
-        )}
-        {step === "purpose" && (
-          <SecondStep
-            clickedPurpose={purpose}
-            handleClick={(e) => handleArrayClick(e, setPurpose)}
-          />
-        )}
-        {step === "style" && (
-          <ThirdStep clickedStyle={style} handleClick={(e) => handleArrayClick(e, setStyle)} />
-        )}
-        {step === "period" && (
-          <FourthStep clickedPeriod={period} handleClick={(e) => handleStringClick(e, setPeriod)} />
-        )}
+          {step === "position" && (
+            <FirstStep
+              clicked={onBoardingForm.position}
+              handleClick={(e) => handleStringClick(e, "position")}
+            />
+          )}
+          {step === "purposes" && (
+            <SecondStep
+              clicked={onBoardingForm.purposes}
+              handleClick={(e) => handleArrayClick(e, "purposes")}
+            />
+          )}
+          {step === "styles" && (
+            <ThirdStep
+              clicked={onBoardingForm.styles}
+              handleClick={(e) => handleArrayClick(e, "styles")}
+            />
+          )}
+          {step === "period" && (
+            <FourthStep
+              clicked={onBoardingForm.period}
+              handleClick={(e) => handleStringClick(e, "period")}
+            />
+          )}
+        </Suspense>
       </article>
 
       <div className="mt-auto px-4 pb-[42px]">
@@ -148,12 +87,13 @@ export default function OnBoardingPage() {
           <Button variant="outline" size="sm" onClick={handlePrevStep}>
             <span className="text-gray-200 text-bold-16">이전</span>
           </Button>
-          <Button
-            disabled={!isFilled}
-            onClick={step === "period" ? handlePostOnboardingData : handleNextStep}
-          >
+          <Button disabled={!isFilled} onClick={step === "period" ? handleSubmit : handleNextStep}>
             <span className="text-white text-bold-16">
-              {step === "period" ? (period ? "작성이 완료되었어요!" : "이제 마지막이에요") : "다음"}
+              {step === "period"
+                ? onBoardingForm.period
+                  ? "작성이 완료되었어요!"
+                  : "이제 마지막이에요"
+                : "다음"}
             </span>
           </Button>
         </div>

--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Link from "next/link";
 
 import { Suspense } from "react";

--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 
 import { Suspense } from "react";

--- a/src/components/OnBoarding/CompleteBox/CompleteBox.tsx
+++ b/src/components/OnBoarding/CompleteBox/CompleteBox.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+
+import Button from "@/components/common/Button/Button";
+import OnboardingProfile from "@/components/OnBoarding/Profile/Profile";
+import OnBoardingTitle from "@/components/OnBoardingTitle/OnBoardingTitle";
+
+import { COMPLETE_DATA } from "@/constants/onBoarding";
+import { PATH } from "@/constants/path";
+
+import { useUserInformationQuery } from "@/hooks/api/userInfo/useUserInformationQuery";
+
+const CompleteBox = () => {
+  const {
+    userData: {
+      data: { name, profileImage },
+    },
+  } = useUserInformationQuery();
+
+  return (
+    <article className="flex flex-col items-center w-full h-full px-5">
+      <OnBoardingTitle textData={COMPLETE_DATA(name)} index={0} subTextColor="text-gray-200" />
+
+      <OnboardingProfile userName={name} profileImage={profileImage} />
+
+      <Link href={PATH.STUDY_ROOM_LIST} className="mt-auto mb-[42px]">
+        <Button size="xl">
+          <span className="text-white text-semibold-16">스터디 찾으러 가기</span>
+        </Button>
+      </Link>
+    </article>
+  );
+};
+
+export default CompleteBox;

--- a/src/components/OnBoarding/FirstStep/FirstStep.tsx
+++ b/src/components/OnBoarding/FirstStep/FirstStep.tsx
@@ -1,29 +1,31 @@
 import Image from "next/image";
 
-import { JOBS_DATA, JOBS_KR_DATA } from "@/constants/onBoarding";
+import { POSITIONS_DATA, POSITIONS_KR_DATA } from "@/constants/onBoarding";
 
-interface FirstStepProp {
-  clickedJob: string;
-  handleClick: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
-}
+import type { OnboardingStepProps } from "@/types/onboarding";
 
-const FirstStep = ({ clickedJob, handleClick }: FirstStepProp) => {
+const FirstStep = ({ clicked: clickedPosition, handleClick }: OnboardingStepProps) => {
   return (
     <div className="flex flex-col items-center w-full h-full">
       <div className="flex justify-center items-center w-full gap-[8px] pt-[60px]">
-        {JOBS_DATA.map((job, index) => (
+        {POSITIONS_DATA.map((position, index) => (
           <button
-            key={`jobs${index}`}
-            value={job}
+            key={`positions${index}`}
+            value={position}
             onClick={handleClick}
             className={`w-[109px] h-[120px] rounded-lg flex flex-col items-center justify-center gap-[20px] ${
-              clickedJob === job
+              clickedPosition === position
                 ? "bg-primary-200 text-primary-500 border border-primary-500 text-medium-16"
                 : "bg-gray-50 text-regular-16"
             }`}
           >
-            <Image src={`/svg/ic-onboarding-${job}.svg`} width={24} height={24} alt={job} />
-            <p>{JOBS_KR_DATA[index]}</p>
+            <Image
+              src={`/svg/ic-onboarding-${position}.svg`}
+              width={24}
+              height={24}
+              alt={position}
+            />
+            <p>{POSITIONS_KR_DATA[index]}</p>
           </button>
         ))}
       </div>

--- a/src/components/OnBoarding/FourthStep/FourthStep.tsx
+++ b/src/components/OnBoarding/FourthStep/FourthStep.tsx
@@ -2,12 +2,9 @@ import TagButton from "@/components/common/TagButton/TagButton";
 
 import { PERIODS_DATA } from "@/constants/onBoarding";
 
-interface FourthStepProp {
-  clickedPeriod: string;
-  handleClick: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
-}
+import type { OnboardingStepProps } from "@/types/onboarding";
 
-const FourthStep = ({ clickedPeriod, handleClick }: FourthStepProp) => {
+const FourthStep = ({ clicked: clickedPeriod, handleClick }: OnboardingStepProps) => {
   return (
     <div className="flex flex-col items-center w-full h-full">
       <div className="w-full pt-[60px] flex flex-col gap-3 justify-center items-start text-regular-16">

--- a/src/components/OnBoarding/Profile/Profile.tsx
+++ b/src/components/OnBoarding/Profile/Profile.tsx
@@ -1,0 +1,66 @@
+import Image from "next/image";
+
+import { POSITIONS_DATA, POSITIONS_KR_DATA } from "@/constants/onBoarding";
+
+import { useOnboardingCompleteQuery } from "@/hooks/api/onboarding/useOnboardingCompleteQuery";
+
+interface OnboardingProfileProps {
+  userName: string;
+  profileImage: string;
+}
+
+const OnboardingProfile = ({ userName, profileImage }: OnboardingProfileProps) => {
+  const { onboardingCompleteData } = useOnboardingCompleteQuery();
+
+  const position = POSITIONS_KR_DATA[POSITIONS_DATA.indexOf(onboardingCompleteData.data.position)];
+  const styles = onboardingCompleteData.data.styles.slice(0, 2).join("﹒");
+
+  return (
+    <div className="relative w-[150px] mt-[77px]">
+      <Image
+        src="/svg/ic-onboarding-complete-back.svg"
+        width={146}
+        height={204}
+        alt="back"
+        priority
+        className="absolute top-0"
+      />
+
+      <div className="relative flex justify-center w-full transform animate-tilt backdrop-blur-[2px]">
+        <div className="w-[146px] h-[204px] border border-gray-100 rounded-lg bg-[#FAFAFF]/70" />
+        <div className="absolute top-0 flex flex-col items-center justify-center pt-6 whitespace-nowrap">
+          <div className="relative w-[80px] h-[80px] flex justify-center bg-gradient-to-tr from-[#FAFAFF]/60 to-[#FAFAFF]/45">
+            <div className="absolute w-[80px] h-[80px] bg-[#0017E2] mix-blend-hue z-10" />
+            <Image
+              src="/svg/ic-badge-nanum-master.svg"
+              width={76}
+              height={75}
+              alt="meetie master"
+            />
+            <Image
+              src={profileImage}
+              width={48}
+              height={48}
+              alt="profile"
+              priority
+              className="absolute top-[25px] z-20 rounded-full"
+            />
+          </div>
+          <p className="text-semibold-14 mt-[6.5px]">{userName}님</p>
+          <p className="text-semibold-10">{position}</p>
+          <p className="text-regular-12 mt-[19px]">{styles}</p>
+        </div>
+      </div>
+
+      <Image
+        src="/svg/ic-onboarding-profile-shadow.svg"
+        width={162}
+        height={15}
+        alt="profile shadow"
+        className="mt-[47px]"
+      />
+    </div>
+  );
+};
+
+export default OnboardingProfile;

--- a/src/components/OnBoarding/SecondStep/SecondStep.tsx
+++ b/src/components/OnBoarding/SecondStep/SecondStep.tsx
@@ -2,12 +2,9 @@ import TagButton from "@/components/common/TagButton/TagButton";
 
 import { PURPOSES_DATA } from "@/constants/onBoarding";
 
-interface SecondStepProp {
-  clickedPurpose: string[];
-  handleClick: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
-}
+import type { OnboardingStepProps } from "@/types/onboarding";
 
-const SecondStep = ({ clickedPurpose, handleClick }: SecondStepProp) => {
+const SecondStep = ({ clicked: clickedPurpose, handleClick }: OnboardingStepProps) => {
   return (
     <div className="flex flex-col items-center w-full h-full">
       <div className="w-full pt-[60px] flex flex-col gap-3 justify-center items-start text-regular-16">

--- a/src/components/OnBoarding/ThirdStep/ThirdStep.tsx
+++ b/src/components/OnBoarding/ThirdStep/ThirdStep.tsx
@@ -2,12 +2,9 @@ import TagButton from "@/components/common/TagButton/TagButton";
 
 import { STYLES_DATA } from "@/constants/onBoarding";
 
-interface ThirdStepProp {
-  clickedStyle: string[];
-  handleClick: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
-}
+import type { OnboardingStepProps } from "@/types/onboarding";
 
-const ThirdStep = ({ clickedStyle, handleClick }: ThirdStepProp) => {
+const ThirdStep = ({ clicked: clickedStyle, handleClick }: OnboardingStepProps) => {
   return (
     <div className="flex flex-col items-center w-full h-full">
       <div className="flex flex-wrap pt-[60px] gap-2">

--- a/src/components/OnBoarding/TitleContainer/TitleContainer.tsx
+++ b/src/components/OnBoarding/TitleContainer/TitleContainer.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import OnBoardingTitle from "@/components/OnBoardingTitle/OnBoardingTitle";
+
+import { QUESTION_DATA } from "@/constants/onBoarding";
+
+import { useUserInformationQuery } from "@/hooks/api/userInfo/useUserInformationQuery";
+
+interface TitleContainerProp {
+  currentStepIndex: number;
+}
+
+const TitleContainer = ({ currentStepIndex }: TitleContainerProp) => {
+  const {
+    userData: {
+      data: { name },
+    },
+  } = useUserInformationQuery();
+
+  return (
+    <OnBoardingTitle
+      textData={QUESTION_DATA(name)}
+      index={currentStepIndex}
+      subTextColor="text-gray-200"
+    />
+  );
+};
+
+export default TitleContainer;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -7,4 +7,6 @@ export const END_POINTS = {
 
   USER_INFO_BY_ID: (id: number) => `/api/user-info/${id}`,
   USER_INFO: (id: string) => `/api/user-info?user_id=${id}`,
+
+  ONBOARDING: "/api/onboarding",
 };

--- a/src/constants/onBoarding.ts
+++ b/src/constants/onBoarding.ts
@@ -18,11 +18,11 @@ export const QUESTION_DATA = (name: string) => [
   },
 ];
 
-export const STEPS_DATA = ["job", "purpose", "style", "period"] as const;
+export const STEPS_DATA = ["position", "purposes", "styles", "period"] as const;
 
-// job
-export const JOBS_DATA = ["designer", "developer", "planner"];
-export const JOBS_KR_DATA = ["디자이너", "개발자", "기획자"];
+// position
+export const POSITIONS_DATA = ["designer", "developer", "planner"];
+export const POSITIONS_KR_DATA = ["디자이너", "개발자", "기획자"];
 
 // purpose
 export const PURPOSES_DATA = ["자기 개발", "툴 능력 향상", "해당 분야의 네트워킹 확장", "취미"];

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -3,4 +3,5 @@ export const QUERY_KEYS = {
   STUDY: "study",
 
   USER_INFO: "userInfo",
+  ONBOARDING_COMPLETE: "onboardingComplete",
 };

--- a/src/hooks/api/onboarding/useOnboardingCompleteQuery.ts
+++ b/src/hooks/api/onboarding/useOnboardingCompleteQuery.ts
@@ -1,0 +1,32 @@
+import type { AxiosError } from "axios";
+
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import { getOnboarding } from "@/apis/onboarding/getOnboarding";
+
+import { QUERY_KEYS } from "@/constants/queryKey";
+
+interface OnboardingCompleteType {
+  position: string;
+  styles: string[];
+}
+
+interface GetOnboardingCompleteResponseType {
+  data: OnboardingCompleteType;
+  message: string;
+  status: number;
+}
+
+export const useOnboardingCompleteQuery = () => {
+  const { data: onboardingCompleteData, isLoading } = useSuspenseQuery<
+    GetOnboardingCompleteResponseType,
+    AxiosError
+  >({
+    queryKey: [QUERY_KEYS.ONBOARDING_COMPLETE],
+    queryFn: () => getOnboarding(),
+  });
+
+  const isExist = onboardingCompleteData.data ? true : false;
+
+  return { onboardingCompleteData, isExist, isLoading };
+};

--- a/src/hooks/api/onboarding/usePostOnboardingMutation.ts
+++ b/src/hooks/api/onboarding/usePostOnboardingMutation.ts
@@ -1,0 +1,18 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { postOnboarding } from "@/apis/onboarding/postOnboarding";
+
+import { queryClient } from "@/components/providers/QueryProvider";
+
+import { QUERY_KEYS } from "@/constants/queryKey";
+
+export const usePostOnboardingMutation = () => {
+  const postOnboardingMutation = useMutation({
+    mutationFn: postOnboarding,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ONBOARDING_COMPLETE] });
+    },
+  });
+
+  return postOnboardingMutation;
+};

--- a/src/hooks/onboarding/useOnboardingForm.ts
+++ b/src/hooks/onboarding/useOnboardingForm.ts
@@ -1,0 +1,90 @@
+import { useRouter } from "next/navigation";
+
+import { useCallback, useState } from "react";
+
+import { STEPS_DATA } from "@/constants/onBoarding";
+import { PATH } from "@/constants/path";
+
+import { usePostOnboardingMutation } from "@/hooks/api/onboarding/usePostOnboardingMutation";
+
+import type { OnboardingFormType } from "@/types/onboarding";
+
+export const useOnboardingForm = () => {
+  const router = useRouter();
+
+  const { mutate: PostOnboardingMutation } = usePostOnboardingMutation();
+
+  const [step, setStep] = useState<"position" | "purposes" | "styles" | "period">("position");
+
+  const [onBoardingForm, setOnboardingForm] = useState<OnboardingFormType>({
+    position: "",
+    purposes: [],
+    styles: [],
+    period: "",
+  });
+
+  const currentStepIndex = STEPS_DATA.indexOf(step);
+  const isFilled = onBoardingForm[step].length !== 0;
+
+  const updateOnboardingForm = useCallback(
+    <Key extends keyof OnboardingFormType>(key: Key, value: OnboardingFormType[Key]) => {
+      setOnboardingForm((prevOnboardingForm) => {
+        const data = {
+          ...prevOnboardingForm,
+          [key]: value,
+        };
+
+        return data;
+      });
+    },
+    [],
+  );
+
+  const handleStringClick = (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    key: keyof OnboardingFormType,
+  ) => {
+    updateOnboardingForm(key, e.currentTarget.value);
+  };
+
+  const handleArrayClick = (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    key: keyof OnboardingFormType,
+  ) => {
+    const newValue = e.currentTarget.value;
+    const prevOnboardingArray = onBoardingForm[key] as string[];
+    const value: string[] = prevOnboardingArray.includes(newValue)
+      ? prevOnboardingArray.filter((prev) => prev !== newValue)
+      : [...prevOnboardingArray, newValue];
+
+    updateOnboardingForm(key, value);
+  };
+
+  const handlePrevStep = () => {
+    step === "position" || setStep(STEPS_DATA[currentStepIndex - 1]);
+  };
+
+  const handleNextStep = () => {
+    step === "period" || setStep(STEPS_DATA[currentStepIndex + 1]);
+  };
+
+  const handleSubmit = async () => {
+    PostOnboardingMutation(onBoardingForm, {
+      onSuccess: () => {
+        router.push(PATH.ONBOARDING_COMPLETE);
+      },
+    });
+  };
+
+  return {
+    step,
+    isFilled,
+    onBoardingForm,
+    currentStepIndex,
+    handleStringClick,
+    handleArrayClick,
+    handlePrevStep,
+    handleNextStep,
+    handleSubmit,
+  };
+};

--- a/src/types/onboarding.ts
+++ b/src/types/onboarding.ts
@@ -1,0 +1,11 @@
+export interface OnboardingFormType {
+  position: string;
+  purposes: string[];
+  styles: string[];
+  period: string;
+}
+
+export interface OnboardingStepProps {
+  clicked: string | string[];
+  handleClick: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+}

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -44,7 +44,8 @@ export async function updateSession(request: NextRequest) {
     !user &&
     request.nextUrl.pathname !== "/login" &&
     request.nextUrl.pathname !== "/" &&
-    request.nextUrl.pathname !== "/auth/redirect"
+    request.nextUrl.pathname !== "/auth/redirect" &&
+    request.nextUrl.pathname !== "/auth/callback"
   ) {
     const url = request.nextUrl.clone();
 


### PR DESCRIPTION
- https://github.com/Meetie-One/Meetie-front/issues/63

## 💡 변경사항 & 이슈
온보딩 데이터, api 리펙토링, 라우팅 설정
<br>

## ✍️ 관련 설명
온보딩 데이터를 하나의 객체로 관리하도록 변경했습니다.
step 컴포넌트로 넘기는 prop의 type을 하나로 통일했습니다.

온보딩 post, get api를 `react-query`와 `axios`를 사용하는 방식으로 변경했습니다.
온보딩 완료 페이지에서 프로필을 컴포넌트로 분리시켰습니다. (재사용을 고려하지 않고 만들어서 재사용을 한다면 수정해야될거같습니다.)

로그인을 했을 때 redirect 페이지에서 온보딩을 완료했는지를 확인하고 완료했으면 스터디 `/study-list`로 라우팅, 아니면 `/walk-whrough`로 라우팅 시키도록 했습니다.

<br>

## ⭐️ Review point
skip 버튼이 있어서 온보딩 과정을 필수로 해야될지 정해야할거같습니다.
로딩처리 부분이 아직 매끄럽지 않아서 추가로 변경해야될거같습니다.
<br>

## 📷 Demo

<br>
