### PR TITLE
115 front task refactor create study room logic

### DIFF
--- a/src/app/api/study-room/route.ts
+++ b/src/app/api/study-room/route.ts
@@ -11,24 +11,22 @@ export async function POST(request: Request) {
     const { error: createStudyRoomError } = await supabase.from("study_room").insert(data);
 
     if (!createStudyRoomError) {
-      // const { error: deleteStudyError } = await supabase
-      //   .from("study")
-      //   .delete()
-      //   .eq("id", data.studyId);
-
       const { error: endDateStudyError } = await supabase
         .from("study")
         .update({ isRecruit: false })
         .eq("id", data.studyId);
 
       if (!endDateStudyError) {
-        return NextResponse.json({ message: "ok", status: 200, data: data.studyId });
+        return NextResponse.json({ message: "ok", data: data.studyId }, { status: 200 });
       }
     }
 
-    return NextResponse.json({ message: "error", status: 400 });
+    return NextResponse.json(
+      { message: "error" },
+      { status: 400, statusText: "잘못된 요청입니다" },
+    );
   } catch (error) {
     console.error(error);
-    return NextResponse.json({ message: "error", status: 500 });
+    return NextResponse.json({ message: "error" }, { status: 500, statusText: "서버 오류 발생" });
   }
 }

--- a/src/app/api/study-room/route.ts
+++ b/src/app/api/study-room/route.ts
@@ -11,12 +11,17 @@ export async function POST(request: Request) {
     const { error: createStudyRoomError } = await supabase.from("study_room").insert(data);
 
     if (!createStudyRoomError) {
-      const { error: deleteStudyError } = await supabase
+      // const { error: deleteStudyError } = await supabase
+      //   .from("study")
+      //   .delete()
+      //   .eq("id", data.studyId);
+
+      const { error: endDateStudyError } = await supabase
         .from("study")
-        .delete()
+        .update({ isRecruit: false })
         .eq("id", data.studyId);
 
-      if (!deleteStudyError) {
+      if (!endDateStudyError) {
         return NextResponse.json({ message: "ok", status: 200, data: data.studyId });
       }
     }

--- a/src/app/study/create/page.tsx
+++ b/src/app/study/create/page.tsx
@@ -12,8 +12,6 @@ export default function CreateStudyPage() {
   const { step, createStudyForm, buttonDisabled, handleMoveStep, updateInputValue, handleSubmit } =
     useCreateStudyForm({});
 
-  console.log(createStudyForm);
-
   return (
     <>
       <Header>

--- a/src/components/Study/StudyDetail/StudyDetail.tsx
+++ b/src/components/Study/StudyDetail/StudyDetail.tsx
@@ -45,11 +45,16 @@ const StudyDetail = () => {
           </Header.RightTextButton>
         )}
       </Header>
+
       <div className="px-4 pt-[64px] pb-[138px]">
         <div className="flex items-center gap-[14px]">
-          <h1 className="text-semibold-24">{data.data.title}</h1>
+          <h1 className="text-semibold-24 max-w-[240px] line-clamp-2 text-ellipsis break-all">
+            {data.data.title}
+          </h1>
           <div className="border border-primary-400 rounded-[20px] py-[4px] px-[14px]">
-            <p className="text-medium-12 text-primary-400">{generateDday(data.data.endDate)}</p>
+            <p className="text-medium-12 text-primary-400">
+              {data.data.isRecruit ? generateDday(data.data.endDate) : "모집 마감"}
+            </p>
           </div>
         </div>
 

--- a/src/components/Study/StudyDetail/StudyDetail.tsx
+++ b/src/components/Study/StudyDetail/StudyDetail.tsx
@@ -70,7 +70,7 @@ const StudyDetail = () => {
               <span className={spanClassName}>
                 {convertDateTime(new Date(data.data.createdAt))}
               </span>
-              <span>조회수 33</span>
+              <span>조회수 {data.data.viewCount}</span>
             </p>
           </div>
         </div>

--- a/src/components/Study/StudyRoomList/StudyCard.tsx
+++ b/src/components/Study/StudyRoomList/StudyCard.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 
-import { format, startOfToday, addDays, differenceInCalendarDays } from "date-fns";
+import { format, startOfToday, addDays } from "date-fns";
 import { ko } from "date-fns/locale";
 
 import Tag from "@/components/common/Tag/Tag";
@@ -10,6 +10,8 @@ import Bookmark from "@/components/Study/Bookmark/Bookmark";
 import { PATH } from "@/constants/path";
 
 import { usePatchStudyMutation } from "@/hooks/api/study/usePatchStudyMutation";
+
+import { generateDday } from "@/utils/date";
 
 import type { StudyListType } from "@/types/study";
 
@@ -25,18 +27,6 @@ const StudyCard = ({ studyData, userId }: StudyCardProps) => {
   const newEndDate = studyData.endDate ?? addDays(newStartDate, 7); // FIXME: null일 때 임의의 7일 added
 
   const isMarked = studyData.bookmarks.length > 0 ? studyData.bookmarks[0].isMarked : false;
-
-  const handleGetDateDiff = () => {
-    const diff = differenceInCalendarDays(newEndDate, new Date());
-    // FIXME: 추후 공통 함수로 적용
-    if (diff < 0) {
-      return "모집 종료";
-    } else if (diff === 0) {
-      return "오늘 마감";
-    } else {
-      return `D-${diff}`;
-    }
-  };
 
   //TODO: 전체 필드 아닌 일부 필드만 업데이트 가능하도록 수정
   const handleUpdateViewCount = () => {
@@ -71,7 +61,9 @@ const StudyCard = ({ studyData, userId }: StudyCardProps) => {
           {studyData.tagList?.map((tag) => <Tag text={tag} isSmall key={tag} />)}
         </div>
         <div className="flex justify-between">
-          <span className="font-bold text-[12px] text-primary-500">{handleGetDateDiff()}</span>
+          <span className="font-bold text-[12px] text-primary-500">
+            {!studyData.isRecruit ? "모집 마감" : generateDday(newEndDate)}
+          </span>
           <div className="flex justify-between">
             <div>
               <Image src="/svg/ic-calandar.svg" alt="icon" width={15} height={15} />

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -42,7 +42,7 @@ export const generateDday = (nowDate: Date | null) => {
   const diff = differenceInCalendarDays(nowDate, new Date());
 
   if (diff < 0) {
-    return "모집 종료";
+    return "모집 마감";
   } else if (diff === 0) {
     return "오늘 마감";
   } else {


### PR DESCRIPTION
- [https://github.com/Meetie-One/Meetie-front/issues/115](https://github.com/Meetie-One/Meetie-front/issues/115)

## 💡 변경사항 & 이슈
스터디 룸 생성 시 스터디 글 로직 변경

## ✍️ 관련 설명
기존에는 스터디 룸 생성 시 스터디는 DB에서 삭제하는 로직이였습니다.

모집중만 보기 필터링을 고려해서 모집이 끝난 글도 남기기로 결정했고 스터디룸 생성시 해당 스터디는 isRecruit가 false 상태로 DB에 존재하게 로직 변경했습니다.

이외에 에러 핸들링만 변경 했습니다

## ⭐️ Review point
.

## 📷 Demo
.
