### PR TITLE
122 front task change style postcard position

### DIFF
--- a/src/components/CommunityPost/List/PostCard/PostCard.tsx
+++ b/src/components/CommunityPost/List/PostCard/PostCard.tsx
@@ -26,16 +26,23 @@ const PostCard = ({ post, isReadMode, className, ...props }: PostCardProps) => {
       )}
       {...props}
     >
-      <div className="flex">
+      <div className="flex whitespace-nowrap">
         <span className="text-regular-12 text-[#434343]">
           {!post.userPosition ? "미정" : post.userPosition}
         </span>
-        {post.position.map((position, index) => (
-          <div className="flex gap-1 items-center ml-1" key={`${post.id}/${position}/${index}`}>
-            <div className="w-0.5 h-0.5 rounded-full bg-[#434343]" />
-            <span className="text-regular-12 text-[#434343]">{position}</span>
-          </div>
-        ))}
+        <div
+          className={`flex flex-wrap text-regular-12 text-[#434343] ${!isReadMode && post.position.length > 5 ? "after:content-['...'] after:ml-0.5" : ""}`}
+        >
+          {post.position.map((position, index) => (
+            <div
+              className={`flex gap-1 items-center ml-1  ${!isReadMode ? "[&:nth-child(n+6)]:hidden" : ""}`}
+              key={`${post.id}/${position}/${index}`}
+            >
+              <div className="w-0.5 h-0.5 rounded-full bg-[#434343]" />
+              <span>{position}</span>
+            </div>
+          ))}
+        </div>
       </div>
 
       <h2 className="text-bold-16 text-[#434343]">{post.title}</h2>

--- a/src/components/CommunityPost/List/PostCard/PostCard.tsx
+++ b/src/components/CommunityPost/List/PostCard/PostCard.tsx
@@ -2,6 +2,8 @@ import Image from "next/image";
 
 import { default as CustomImage } from "@/components/common/Image/Image";
 
+import { POSITION_DATA } from "@/constants/community";
+
 import { cn } from "@/utils/className";
 import { convertDate } from "@/utils/date";
 
@@ -18,6 +20,9 @@ const BLUR_IMAGE =
 const PostCard = ({ post, isReadMode, className, ...props }: PostCardProps) => {
   const mainImage = post.images[0];
 
+  const positionItemClassName = "flex gap-1 items-center ml-1";
+  const markerClassName = "w-0.5 h-0.5 rounded-full bg-[#434343]";
+
   return (
     <li
       className={cn(
@@ -26,23 +31,28 @@ const PostCard = ({ post, isReadMode, className, ...props }: PostCardProps) => {
       )}
       {...props}
     >
-      <div className="flex whitespace-nowrap">
-        <span className="text-regular-12 text-[#434343]">
-          {!post.userPosition ? "미정" : post.userPosition}
-        </span>
-        <div
-          className={`flex flex-wrap text-regular-12 text-[#434343] ${!isReadMode && post.position.length > 5 ? "after:content-['...'] after:ml-0.5" : ""}`}
-        >
-          {post.position.map((position, index) => (
-            <div
-              className={`flex gap-1 items-center ml-1  ${!isReadMode ? "[&:nth-child(n+6)]:hidden" : ""}`}
-              key={`${post.id}/${position}/${index}`}
-            >
-              <div className="w-0.5 h-0.5 rounded-full bg-[#434343]" />
-              <span>{position}</span>
-            </div>
-          ))}
-        </div>
+      <div className="flex whitespace-nowrap text-regular-12 text-[#434343] ">
+        <span>{!post.userPosition ? "미정" : post.userPosition}</span>
+        {post.position.length === POSITION_DATA.length ? (
+          <div className={positionItemClassName}>
+            <div className={markerClassName} />
+            <span>전체</span>
+          </div>
+        ) : (
+          <div
+            className={`flex flex-wrap ${!isReadMode && post.position.length > 5 ? "after:content-['...'] after:ml-0.5" : ""}`}
+          >
+            {post.position.map((position, index) => (
+              <div
+                className={cn(positionItemClassName, isReadMode ? "" : "[&:nth-child(n+6)]:hidden")}
+                key={`${post.id}/${position}/${index}`}
+              >
+                <div className={markerClassName} />
+                <span>{position}</span>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       <h2 className="text-bold-16 text-[#434343]">{post.title}</h2>


### PR DESCRIPTION
- https://github.com/Meetie-One/Meetie-front/issues/122

## 💡 변경사항 & 이슈
커뮤니티 게시글 카드 게시 분야 디자인 변경
<br>

## ✍️ 관련 설명
게시 분야의 개수가 많아질 때 디자인이 깨지는 문제를 해결했습니다.

커뮤니티 페이지에서는 여러 줄로 게시 분야가 표시되는 것 보다 한 줄로 보여지는 것이 더 깔끔하다 느껴져서 게시 분야 태그를 생략하는 방식을 적용했습니다.

read 페이지에서는 모든 게시 분야를 보여줘야 할 필요가 있다고 생각되어 줄바꿈으로 게시 분야를 모두 표시했습니다.

전체 선택을 한 경우 게시 분야가 `전체`로 표시될 수 있도록 수정했습니다.
<br>

## ⭐️ Review point

<br>

## 📷 Demo
- community
![image](https://github.com/user-attachments/assets/2b1dc0c8-026f-48b5-9c21-a2bdced837d7)

- community/[id]
![image](https://github.com/user-attachments/assets/cef89795-94c0-449e-b8d4-2c53f8b8686f)

<br>
